### PR TITLE
Add teacher-only admin mode for activity registration

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Sign up/unregister students for activities (teachers only)
+- Teacher login/logout for admin actions
 
 ## Getting Started
 
@@ -30,7 +31,20 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity (teacher login required)                    |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity (teacher login required)            |
+| POST   | `/auth/login?username=<username>&password=<password>`             | Teacher login                                                       |
+| POST   | `/auth/logout`                                                     | Teacher logout                                                      |
+| GET    | `/auth/status`                                                     | Get current auth/session status                                     |
+
+## Teacher Accounts
+
+Teacher credentials are stored in `teachers.json`.
+
+Default credentials:
+
+- `ms.smith` / `teach123`
+- `mr.johnson` / `teach456`
 
 ## Data Model
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,16 @@
   </head>
   <body>
     <header>
+      <div class="auth-toolbar">
+        <button id="user-menu-button" class="icon-button" aria-label="User menu">👤</button>
+        <div id="user-menu" class="user-menu hidden">
+          <button id="open-login" type="button">Login</button>
+          <button id="logout" type="button" class="hidden">Logout</button>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <p id="teacher-status" class="teacher-status">Viewing as student</p>
     </header>
 
     <main>
@@ -23,6 +31,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="teacher-only-note" class="info-note">
+          Teachers must log in to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -44,6 +55,27 @@
     <footer>
       <p>&copy; 2023 Mergington High School</p>
     </footer>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-content">
+        <h3 id="login-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" id="close-login" class="secondary">Cancel</button>
+          </div>
+        </form>
+        <div id="login-message" class="hidden"></div>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -26,6 +27,61 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.teacher-status {
+  margin-top: 8px;
+  font-size: 14px;
+  opacity: 0.9;
+}
+
+.auth-toolbar {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.icon-button {
+  background: transparent;
+  border: 1px solid #fff;
+  border-radius: 999px;
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0;
+}
+
+.icon-button:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.user-menu {
+  position: absolute;
+  top: 42px;
+  right: 0;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  min-width: 110px;
+  z-index: 10;
+  padding: 6px;
+}
+
+.user-menu button {
+  width: 100%;
+  margin: 4px 0;
+  text-align: left;
+  background: #f8f8f8;
+  color: #333;
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+.user-menu button:hover {
+  background: #ececec;
 }
 
 main {
@@ -134,6 +190,15 @@ section h3 {
   margin-bottom: 15px;
 }
 
+.info-note {
+  margin-bottom: 12px;
+  background-color: #fff8e1;
+  color: #8a6d3b;
+  border: 1px solid #f0dba5;
+  padding: 10px;
+  border-radius: 4px;
+}
+
 .form-group label {
   display: block;
   margin-bottom: 5px;
@@ -190,6 +255,42 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  width: 90%;
+  max-width: 420px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.secondary {
+  background: #6c757d;
+}
+
+.secondary:hover {
+  background: #5a6268;
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,10 @@
+[
+  {
+    "username": "ms.smith",
+    "password": "teach123"
+  },
+  {
+    "username": "mr.johnson",
+    "password": "teach456"
+  }
+]


### PR DESCRIPTION
## Summary
Implements issue #5 (Admin Mode) by restricting registration mutations to logged-in teachers.

## What changed
- Added session-based teacher authentication in backend:
  - `POST /auth/login`
  - `POST /auth/logout`
  - `GET /auth/status`
- Enforced teacher-only access on:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Added teacher credentials file:
  - `src/teachers.json`
- Updated frontend UI:
  - top-right user icon and login/logout menu
  - teacher login modal
  - student mode can view participants only
  - teacher mode can register/unregister students
- Updated documentation in `src/README.md`.

## Notes
- This follows the issue requirement to store teacher usernames/passwords in a JSON file for now.
- No database migration was introduced in this PR.

Closes #5